### PR TITLE
Run in sync

### DIFF
--- a/examples/sync_async/batou
+++ b/examples/sync_async/batou
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+#
+# This file is managed by batou. Don't edit directly. Use the './batou update'
+# command to adjust versions.
+#
+# This file is intended to be as small as possible getting batou working
+# somehow and then use that code to continue.
+
+import os
+import shutil
+import sys
+import subprocess
+
+# We use this to trick the simple templating so you can
+# download and copy this file to bootstrap a new batou installation.
+BOOTSTRAP_VERSION_MARKER = '{' + '{version}' + '}'
+
+version = os.environ.get('BATOU_VERSION', '')
+develop = os.environ.get('BATOU_DEVELOP', '../..')
+
+
+def cmd(c, quiet=False):
+    try:
+        subprocess.check_output([c], stderr=subprocess.PIPE, shell=True)
+    except subprocess.CalledProcessError as e:
+        if not quiet:
+            print("{} returned with exit code {}".format(c, e.returncode))
+            print(e.output)
+        raise
+
+
+def install_venv():
+    print('Preparing virtualenv in .batou ...')
+    # Discover the right venv cmd. Or let batou figure that out later in a
+    # second phase?
+    # XXX Give advice if virtualenv isn't there.
+    for fast in ['-F', '--fast']:
+        while fast in sys.argv:
+            sys.argv.remove(fast)
+    cmd('python3 -m venv .batou')
+
+
+def install_pip():
+    # XXX give advice if we can't get the right pip version
+    cmd('.batou/bin/pip install "pip>=8.0"')
+
+
+base = os.path.dirname(__file__) or '.'
+os.chdir(base)
+
+# clear PYTHONPATH variable to get a defined environment
+if 'PYTHONPATH' in os.environ:
+    del os.environ['PYTHONPATH']
+
+needs_reset = False
+
+if os.path.exists('.batou/bin/python2'):
+    needs_reset = True
+
+if '--reset' in sys.argv:
+    needs_reset = True
+
+if needs_reset:
+    print("Resetting batou env ...")
+    cmd('rm -rf .batou')
+
+# Do we have a virtualenv?
+if not os.path.exists(base + '/.batou'):
+    install_venv()
+
+
+def prepare():
+    global version, develop
+
+    try:
+        install_pip()
+    except Exception:
+        # Hum. This venv is probably broken. Remove and restart."
+        shutil.rmtree('.batou')
+        install_venv()
+        install_pip()
+
+    try:
+        cmd('.batou/bin/python -c \'import batou.bootstrap\'', quiet=True)
+    except Exception:
+        missing = True
+    else:
+        missing = False
+
+    if missing or develop:
+        if missing:
+            print('Pre-installing batou - this can take a while...')
+        if version == BOOTSTRAP_VERSION_MARKER:
+            # we're bootstrapping a new project. just get whatever version.
+            # this will self-destruct this file later. :)
+            develop = ''
+            spec = 'batou --pre'
+        elif develop:
+            spec = '-e {}'.format(develop)
+        else:
+            spec = 'batou=={}'.format(version)
+
+        cmd('.batou/bin/pip install --ignore-installed {}'.format(spec))
+
+
+if '--fast' not in sys.argv and '-F' not in sys.argv:
+    prepare()
+
+
+os.environ['BATOU_VERSION'] = version
+os.environ['BATOU_DEVELOP'] = develop
+
+
+# Pass control over the bare-bone batou's bootstrapping code. Good luck!
+os.execv('.batou/bin/python',
+         ['.batou/bin/python', '-c',
+          'import batou.bootstrap; batou.bootstrap.bootstrap()'] + sys.argv)

--- a/examples/sync_async/components/component1/component.py
+++ b/examples/sync_async/components/component1/component.py
@@ -1,0 +1,13 @@
+from batou.component import Component
+
+
+class Component1(Component):
+
+    def configure(self):
+        pass
+
+
+class ComponentSub(Component):
+
+    def configure(self):
+        pass

--- a/examples/sync_async/components/component2/component.py
+++ b/examples/sync_async/components/component2/component.py
@@ -1,0 +1,8 @@
+from batou.component import Component
+
+
+class Component2(Component):
+
+    def configure(self):
+        self.require_one("sub")
+        pass

--- a/examples/sync_async/components/component_sub/component.py
+++ b/examples/sync_async/components/component_sub/component.py
@@ -1,0 +1,7 @@
+from batou.component import Component
+
+
+class ComponentSub(Component):
+
+    def configure(self):
+        self.provide('sub', 'test')

--- a/examples/sync_async/environments/ignores.cfg
+++ b/examples/sync_async/environments/ignores.cfg
@@ -1,0 +1,6 @@
+[environment]
+connect_method = local
+
+[hosts]
+localhost = component1, component2
+!otherhost = component1, component2, componentsub

--- a/src/batou/deploy.py
+++ b/src/batou/deploy.py
@@ -142,12 +142,12 @@ class Deployment(object):
         reference_node = [h for h in list(self.environment.hosts.values())
                           if not h.ignore][0]
 
-        if self.run_async:
-            self.loop = asyncio.get_event_loop()
-            self.taskpool = ThreadPoolExecutor(10)
-            self.loop.set_default_executor(self.taskpool)
-            self._launch_components(reference_node.root_dependencies())
+        self.loop = asyncio.get_event_loop()
+        self.taskpool = ThreadPoolExecutor(10)
+        self.loop.set_default_executor(self.taskpool)
 
+        if self.run_async:
+            self._launch_components(reference_node.root_dependencies())
             pending = asyncio.Task.all_tasks()
             while pending:
                 self.loop.run_until_complete(asyncio.gather(*pending))

--- a/src/batou/deploy.py
+++ b/src/batou/deploy.py
@@ -152,7 +152,11 @@ class Deployment(object):
         else:
             todolist = reference_node.root_dependencies()
             for key, info in list(todolist.items()):
-                self._launch_components({key: info})
+                if info['dependencies']:
+                    continue
+                del todolist[key]
+                asyncio.ensure_future(
+                    self._deploy_component(key, info, todolist))
                 pending = asyncio.Task.all_tasks()
                 while pending:
                     self.loop.run_until_complete(asyncio.gather(*pending))

--- a/src/batou/deploy.py
+++ b/src/batou/deploy.py
@@ -99,9 +99,6 @@ class Deployment(object):
                 hosts[key[0]] = {}
             hosts[key[0]][key] = info
         for host, todolist in hosts.items():
-            output.step(key[0],
-                        "Deploying all components independend "
-                        "from other hosts")
             self._launch_components(todolist, processed)
             self._process_tasks()
             if todolist:

--- a/src/batou/tests/test_endtoend.py
+++ b/src/batou/tests/test_endtoend.py
@@ -117,3 +117,11 @@ otherhost: Skipping component fail2 ... (Host ignored)
 ============================= DEPLOYMENT FINISHED ============================\
 ==
 """)
+
+
+def test_example_async():
+    os.chdir('examples/sync_async')
+    out, _ = cmd('./batou deploy ignores')
+    assert out == Ellipsis("""\
+batou/2\
+""")

--- a/src/batou/tests/test_endtoend.py
+++ b/src/batou/tests/test_endtoend.py
@@ -119,9 +119,31 @@ otherhost: Skipping component fail2 ... (Host ignored)
 """)
 
 
-def test_example_async():
+def test_example_hostwise_deployment():
     os.chdir('examples/sync_async')
     out, _ = cmd('./batou deploy ignores')
     assert out == Ellipsis("""\
-batou/2\
+batou/2... (cpython 3...)
+================================== Preparing =================================\
+==
+main: Loading environment `ignores`...
+main: Verifying repository ...
+main: Loading secrets ...
+================================ Connecting ... ==============================\
+==
+localhost: Connecting via local (1/2)
+otherhost: Connection ignored (2/2)
+============================ Configuring model ... ===========================\
+==
+==================== Waiting for remaining connections ... ===================\
+==
+================================== Deploying =================================\
+==
+otherhost: Skipping component component1 ... (Host ignored)
+otherhost: Skipping component componentsub ... (Host ignored)
+otherhost: Skipping component component2 ... (Host ignored)
+localhost: Deploying component component1 ...
+localhost: Deploying component component2 ...
+============================= DEPLOYMENT FINISHED ============================\
+==
 """)


### PR DESCRIPTION
Bei dem Versuch die Komponenten in einfachen Chunks seriell abzuarbeiten fiel uns auf, dass wir damit keine Garantie über z.B. Restarts von Services auf einzelnen Hosts erreichen können.

Wir verfolgen nun folgenden Ansatz:
* Komponenten werden hostweise deployt
* Komponenten mit Abhängigkeit werden erst deployt, wenn die Komponenten ohne Abhängigkeiten abgearbeitet sind
* Sind die Abhängigkeiten auf einem anderen Host, wird erst der andere Host abgearbeitet

Das Deployment einzelner Komponenten für einen Hosts erfolgt wie bisher asynchron.

Weiterhin gibt es die Möglichkeit unter Berücksichtigung der Komponentenabhängigkeiten alles wie bisher asynchron zu deployen. Allerdings ist das hostweise Deployment der default, da dies auch bei Batou1.0 der Default war.

[Relevant sind die Commits ab 30. Januar. Die vorigen Commits zeigen lediglich warum der erste Ansatz nicht funktionierte]